### PR TITLE
#40 시간 설정에서 초 삭제

### DIFF
--- a/Toki/Views/TimerSetupView.swift
+++ b/Toki/Views/TimerSetupView.swift
@@ -16,7 +16,7 @@ struct TimerSetupView: View {
             let mainSeconds = screenVM.mainMinutes * 60 + screenVM.mainSeconds
 
             VStack(spacing: 8) {
-                HStack(spacing: 12) {
+                HStack(spacing: 8) {
                     Picker(
                         "분",
                         selection: Binding<Int>(
@@ -29,24 +29,9 @@ struct TimerSetupView: View {
                         }
                     }
                     .pickerStyle(.wheel)
-                    .frame(maxWidth: .infinity)
+                    .frame(width: 60)
                     
-                    Text(":")
-                        .font(.title3)
-
-                    Picker(
-                        "초",
-                        selection: Binding<Int>(
-                            get: { screenVM.mainSeconds },
-                            set: { screenVM.mainSeconds = $0 }
-                        )
-                    ) {
-                        ForEach(0..<60, id: \.self) { s in
-                            Text("\(s)").font(.title3)
-                        }
-                    }
-                    .pickerStyle(.wheel)
-                    .frame(maxWidth: .infinity)
+                    Text("분").font(.title3)
                 }
                 .frame(height: 180)
             }


### PR DESCRIPTION
\* 변경 내용 *
- 시간 설정에서 초 단위 삭제
- 시간 설정에서 분 단위 텍스트 추가

\* 추가 공유 *
- 타이머 동작 시에는 초 단위 유지
- 아이폰 기본 타이머 UI를 참고하려 했는데, Picker의 선택 표시용 회색 프레임 안에만 분 단위 텍스트를 작성하는 건 UIKit으로만 가능한 것 같아서 따로 작성해두었습니다.

\* 적용 화면 *

<img width="200" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-17 at 23 16 12" src="https://github.com/user-attachments/assets/fe5ecc5f-8efc-4b6f-b544-5f0e1d08bf45" />
<img width="200" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-17 at 23 16 23" src="https://github.com/user-attachments/assets/c30021bb-33a2-4459-98fd-04b7bafe4c87" />

\* 관련 이슈 *
Closes #40 시간 설정에서 분만 남기고 초를 삭제합니다